### PR TITLE
Herokuデプロイに必要なGemfile.lockの更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,10 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.3-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.3)
     public_suffix (5.0.1)
     puma (5.6.6)
@@ -210,6 +214,8 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
git push heroku mainに必要なGemfile.lockの情報が抜けていましたので、修正しております。
ご確認よろしくお願いします。

[![Image from Gyazo](https://i.gyazo.com/5a7945617c6fcc98eb31afad05eb4676.png)](https://gyazo.com/5a7945617c6fcc98eb31afad05eb4676)